### PR TITLE
Fix typo in command line argument

### DIFF
--- a/flags.py
+++ b/flags.py
@@ -71,7 +71,7 @@ def make():
                         help="suffix for the test environment name")
 
     # procgen
-    parser.add_argument("-use_bg", "--environment.common.use_background", type=bool, default=True,
+    parser.add_argument("-use_bg", "--environment.common.use_backgrounds", type=bool, default=True,
                         help="use background - only for procgen envs")
     parser.add_argument("-use_mono_asset", "--environment.common.use_monochrome_assets", type=bool, default=False,
                         help="use monochrome assets - only for procgen envs")


### PR DESCRIPTION
This typo makes it so the `use_backgrounds` setting has no effect.

See here for the correct naming:
https://github.com/modanesh/YRC-Bench/blob/cb1108da8f82cc5e417669f673d0d48b19154849/configs/common.yaml#L48

The effect is that the value will always fall back to the common.yaml (True) and it is impossible to disable backgrounds.